### PR TITLE
rework exo1 to use a premade image

### DIFF
--- a/exo1/Dockerfile
+++ b/exo1/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:latest
-
-COPY entrypoint.sh /entrypoint.sh
-
-RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]

--- a/exo1/README.md
+++ b/exo1/README.md
@@ -14,38 +14,24 @@ Tu viens de télécharger une **image Docker** contenant un flag caché. L'image
 
 ### 🚀 Instructions
 
-1. **Construire et lancer l'image Docker** :
-   - Utilise le Dockerfile dans le répertoire courant pour construire et lancer l'image Docker.
+1. **Lancer l'image Docker** :
+   Pour ce faire, utilise la commande suivante dans ton terminal :
 
-   Pour ce faire, utilise les commandes suivantes dans ton terminal :
-
-   1. **Construire l'image Docker** :
       ```bash
-      docker build -t docker-ctf .
-      ```
-
-   2. **Lancer l'image Docker** dans un conteneur interactif :
-      ```bash
-      docker run -it docker-ctf
+      docker run -it ibertran/docker-ctf
       ```
 
 2. **Explorer le conteneur pour trouver le flag** :
-   Une fois dans le conteneur, tu devras explorer l'environnement du conteneur pour trouver le flag caché. Voici quelques pistes pour t'aider à progresser dans la recherche.
-
----
-
-### 🚨 Contrainte importante
-
-**Tu peux voir le flag dans le script `.sh` (par exemple, `entrypoint.sh`), mais il est strictement interdit d'y aller directement**, idem pour le sous-dossier solutions. Tu devras utiliser des techniques d'exploration du conteneur pour découvrir où il est caché, sans ouvrir ce fichier directement.
+   Une fois dans le conteneur, tu devras explorer l'environnement du conteneur pour trouver le flag caché.
 
 ---
 
 ### 💡 Indices
 
-Voici quelques outils et stratégies qui pourraient t’aider à localiser le flag caché :
+Voici un outil qui pourrait t’aider à localiser le flag caché :
 
 - **`docker inspect`** : Utilise cette commande pour obtenir des informations détaillées sur l'image Docker, comme le point d'entrée (`ENTRYPOINT`), les volumes, et d'autres paramètres de configuration qui pourraient t'aider à trouver des indices.
 
-  Exemple de commande :
   ```bash
-  docker inspect docker-ctf
+  docker inspect ibertran/docker-ctf
+  ```

--- a/exo1/entrypoint.sh
+++ b/exo1/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-mkdir -p /opt/.hidden_folder
-
-echo "FLAG{Docker<3}" > /opt/.hidden_folder/.flag.txt
-
-echo "Bienvenue dans le CTF Docker. Explorez le conteneur pour trouver le flag !"
-exec /bin/sh

--- a/exo1/solutions/secret_flag.txt
+++ b/exo1/solutions/secret_flag.txt
@@ -1,1 +1,0 @@
-bouh, c'est pas le bon


### PR DESCRIPTION
This pull request removes the custom Dockerfile and associated scripts for the `exo1` challenge, replacing them with a prebuilt Docker image. Additionally, the README instructions have been updated to reflect these changes, simplifying the setup process for users.